### PR TITLE
Add minimum and maximum photos per row constraints in rows layout

### DIFF
--- a/src/PhotoAlbum.tsx
+++ b/src/PhotoAlbum.tsx
@@ -14,6 +14,8 @@ const resolveLayoutOptions = <T extends Photo>({
     onClick,
     viewportWidth,
     containerWidth,
+    minRowCount,
+    maxRowCount,
     targetRowHeight,
     columns,
     spacing,
@@ -36,6 +38,8 @@ const resolveLayoutOptions = <T extends Photo>({
         (w) => w / 3,
         (w) => w / 2,
     ]),
+    minRowCount,
+    maxRowCount,
     sizes,
 });
 

--- a/src/PhotoAlbum.tsx
+++ b/src/PhotoAlbum.tsx
@@ -14,8 +14,8 @@ const resolveLayoutOptions = <T extends Photo>({
     onClick,
     viewportWidth,
     containerWidth,
-    minRowCount,
-    maxRowCount,
+    minPhotoCount,
+    maxPhotoCount,
     targetRowHeight,
     columns,
     spacing,
@@ -38,8 +38,8 @@ const resolveLayoutOptions = <T extends Photo>({
         (w) => w / 3,
         (w) => w / 2,
     ]),
-    minRowCount,
-    maxRowCount,
+    minPhotoCount,
+    maxPhotoCount,
     sizes,
 });
 

--- a/src/PhotoAlbum.tsx
+++ b/src/PhotoAlbum.tsx
@@ -14,9 +14,8 @@ const resolveLayoutOptions = <T extends Photo>({
     onClick,
     viewportWidth,
     containerWidth,
-    minPhotoCount,
-    maxPhotoCount,
     targetRowHeight,
+    rowConstraints,
     columns,
     spacing,
     padding,
@@ -38,9 +37,8 @@ const resolveLayoutOptions = <T extends Photo>({
         (w) => w / 3,
         (w) => w / 2,
     ]),
-    minPhotoCount,
-    maxPhotoCount,
     sizes,
+    rowConstraints,
 });
 
 const PhotoAlbum = <T extends Photo>(props: PhotoAlbumProps<T>): JSX.Element => {

--- a/src/layouts/rows.ts
+++ b/src/layouts/rows.ts
@@ -50,14 +50,14 @@ const makeGetNeighbors =
         photos,
         layoutOptions,
         targetRowHeight,
-        minRowCount,
+        minPhotoCount,
         limitNodeSearch,
         instrumentation,
     }: {
         photos: Array<Photo>;
         layoutOptions: RowsLayoutOptions;
         targetRowHeight: number;
-        minRowCount?: number;
+        minPhotoCount?: number;
         limitNodeSearch: number;
         instrumentation?: Instrumentation;
     }) =>
@@ -66,7 +66,7 @@ const makeGetNeighbors =
         const results: { [key: string]: number } = {};
         const start = +node;
         results[+start] = 0;
-        const startOffset = minRowCount ? minRowCount : 1;
+        const startOffset = minPhotoCount ? minPhotoCount : 1;
         for (let i = start + startOffset; i < photos.length + 1; i += 1) {
             if (i - start > limitNodeSearch && !instrumentation?.fullGraphSearch) break;
             const currentCost = cost(photos, start, i, containerWidth, targetRowHeight, spacing, padding);
@@ -87,7 +87,7 @@ const computeRowsLayout = <T extends Photo = Photo>({
     layoutOptions: RowsLayoutOptions;
     instrumentation?: Instrumentation;
 }): RowsLayoutModel<T> => {
-    const { spacing, padding, containerWidth, targetRowHeight, minRowCount, maxRowCount } = layoutOptions;
+    const { spacing, padding, containerWidth, targetRowHeight, minPhotoCount, maxPhotoCount } = layoutOptions;
 
     instrumentation?.onStartLayoutComputation?.();
 
@@ -97,8 +97,8 @@ const computeRowsLayout = <T extends Photo = Photo>({
         photos,
         layoutOptions,
         targetRowHeight,
-        minRowCount,
-        limitNodeSearch: maxRowCount && maxRowCount < limitNodeSearch ? maxRowCount : limitNodeSearch,
+        minPhotoCount,
+        limitNodeSearch: maxPhotoCount && maxPhotoCount < limitNodeSearch ? maxPhotoCount : limitNodeSearch,
         instrumentation,
     });
 

--- a/src/layouts/rows.ts
+++ b/src/layouts/rows.ts
@@ -50,12 +50,14 @@ const makeGetNeighbors =
         photos,
         layoutOptions,
         targetRowHeight,
+        minRowCount,
         limitNodeSearch,
         instrumentation,
     }: {
         photos: Array<Photo>;
         layoutOptions: RowsLayoutOptions;
         targetRowHeight: number;
+        minRowCount?: number;
         limitNodeSearch: number;
         instrumentation?: Instrumentation;
     }) =>
@@ -64,7 +66,8 @@ const makeGetNeighbors =
         const results: { [key: string]: number } = {};
         const start = +node;
         results[+start] = 0;
-        for (let i = start + 1; i < photos.length + 1; i += 1) {
+        const startOffset = minRowCount ? minRowCount : 1;
+        for (let i = start + startOffset; i < photos.length + 1; i += 1) {
             if (i - start > limitNodeSearch && !instrumentation?.fullGraphSearch) break;
             const currentCost = cost(photos, start, i, containerWidth, targetRowHeight, spacing, padding);
             if (currentCost === undefined) break;
@@ -84,7 +87,7 @@ const computeRowsLayout = <T extends Photo = Photo>({
     layoutOptions: RowsLayoutOptions;
     instrumentation?: Instrumentation;
 }): RowsLayoutModel<T> => {
-    const { spacing, padding, containerWidth, targetRowHeight } = layoutOptions;
+    const { spacing, padding, containerWidth, targetRowHeight, minRowCount, maxRowCount } = layoutOptions;
 
     instrumentation?.onStartLayoutComputation?.();
 
@@ -94,7 +97,8 @@ const computeRowsLayout = <T extends Photo = Photo>({
         photos,
         layoutOptions,
         targetRowHeight,
-        limitNodeSearch,
+        minRowCount,
+        limitNodeSearch: maxRowCount && maxRowCount < limitNodeSearch ? maxRowCount : limitNodeSearch,
         instrumentation,
     });
 

--- a/src/layouts/rows.ts
+++ b/src/layouts/rows.ts
@@ -57,7 +57,6 @@ const makeGetNeighbors =
         photos: Array<Photo>;
         layoutOptions: RowsLayoutOptions;
         targetRowHeight: number;
-        minPhotoCount?: number;
         limitNodeSearch: number;
         rowConstraints?: RowConstraints;
         instrumentation?: Instrumentation;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -82,12 +82,10 @@ export type PhotoAlbumProps<T extends Photo = Photo> = {
     spacing?: ResponsiveParameter;
     /** Padding around each image in the photo album. */
     padding?: ResponsiveParameter;
-    /** min photos in a row in 'rows' layout */
-    minPhotoCount?: number;
-    /** max photos in a row in 'rows' layout */
-    maxPhotoCount?: number;
     /** Target row height in the 'rows' layout. */
     targetRowHeight?: ResponsiveParameter;
+    /** Additional row constraints */
+    rowConstraints?: RowConstraints;
     /** Photo album width at various viewport sizes. */
     sizes?: ResponsiveSizes;
     /** Photo click callback function. */
@@ -132,10 +130,8 @@ export type RowsLayoutOptions = GenericLayoutOptions & {
     layout: Extract<LayoutType, "rows">;
     /** target row height in 'rows' layout */
     targetRowHeight: number;
-    /** min photos in a row in 'rows' layout */
-    minPhotoCount?: number;
-    /** max photos in a row in 'rows' layout */
-    maxPhotoCount?: number;
+    /** Additional row constraints */
+    rowConstraints?: RowConstraints;
 };
 
 export type ColumnsLayoutOptions = GenericLayoutOptions & {
@@ -190,6 +186,13 @@ export type RenderColumnContainer = (props: PropsWithChildren<ColumnContainerPro
 export type ResizeObserverProvider = (
     callback: (entries: ResizeObserverEntry[], observer: ResizeObserver) => void
 ) => ResizeObserver;
+
+export type RowConstraints = {
+    /** minimum number of photos in a row in 'rows' layout */
+    minPhotos?: number;
+    /** maximum number of photos in a row in 'rows' layout */
+    maxPhotos?: number;
+};
 
 /** internal instrumentation for research and performance testing purposes, subject to change without notice */
 export type Instrumentation = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -82,6 +82,10 @@ export type PhotoAlbumProps<T extends Photo = Photo> = {
     spacing?: ResponsiveParameter;
     /** Padding around each image in the photo album. */
     padding?: ResponsiveParameter;
+    /** min photos in a row in 'rows' layout */
+    minRowCount?: number;
+    /** max photos in a row in 'rows' layout */
+    maxRowCount?: number;
     /** Target row height in the 'rows' layout. */
     targetRowHeight?: ResponsiveParameter;
     /** Photo album width at various viewport sizes. */
@@ -128,6 +132,10 @@ export type RowsLayoutOptions = GenericLayoutOptions & {
     layout: Extract<LayoutType, "rows">;
     /** target row height in 'rows' layout */
     targetRowHeight: number;
+    /** min photos in a row in 'rows' layout */
+    minRowCount?: number;
+    /** max photos in a row in 'rows' layout */
+    maxRowCount?: number;
 };
 
 export type ColumnsLayoutOptions = GenericLayoutOptions & {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -83,9 +83,9 @@ export type PhotoAlbumProps<T extends Photo = Photo> = {
     /** Padding around each image in the photo album. */
     padding?: ResponsiveParameter;
     /** min photos in a row in 'rows' layout */
-    minRowCount?: number;
+    minPhotoCount?: number;
     /** max photos in a row in 'rows' layout */
-    maxRowCount?: number;
+    maxPhotoCount?: number;
     /** Target row height in the 'rows' layout. */
     targetRowHeight?: ResponsiveParameter;
     /** Photo album width at various viewport sizes. */
@@ -133,9 +133,9 @@ export type RowsLayoutOptions = GenericLayoutOptions & {
     /** target row height in 'rows' layout */
     targetRowHeight: number;
     /** min photos in a row in 'rows' layout */
-    minRowCount?: number;
+    minPhotoCount?: number;
     /** max photos in a row in 'rows' layout */
-    maxRowCount?: number;
+    maxPhotoCount?: number;
 };
 
 export type ColumnsLayoutOptions = GenericLayoutOptions & {

--- a/test/PhotoAlbum.test.tsx
+++ b/test/PhotoAlbum.test.tsx
@@ -56,11 +56,11 @@ describe("PhotoAlbum", () => {
     });
 
     it("supports minimum number of elements in a row ", () => {
-        whenAskedToRender(<PhotoAlbum layout={"rows"} photos={photos} minRowCount={3} />);
+        whenAskedToRender(<PhotoAlbum layout={"rows"} photos={photos} minPhotoCount={3} />);
     });
 
     it("supports maximum number of elements in a row ", () => {
-        whenAskedToRender(<PhotoAlbum layout={"rows"} photos={photos} maxRowCount={4} />);
+        whenAskedToRender(<PhotoAlbum layout={"rows"} photos={photos} maxPhotoCount={4} />);
     });
 
     it("renders columns layout correctly when there isn't enough photos", () => {

--- a/test/PhotoAlbum.test.tsx
+++ b/test/PhotoAlbum.test.tsx
@@ -55,12 +55,12 @@ describe("PhotoAlbum", () => {
         whenAskedToRender(<PhotoAlbum layout={"rows"} photos={photos} padding={10} />);
     });
 
-    it("supports minimum number of elements in a row ", () => {
-        whenAskedToRender(<PhotoAlbum layout={"rows"} photos={photos} minPhotoCount={3} />);
+    it("supports minimum number of elements in a row", () => {
+        whenAskedToRender(<PhotoAlbum layout={"rows"} photos={photos} rowConstraints={{ minPhotos: 3 }} />);
     });
 
-    it("supports maximum number of elements in a row ", () => {
-        whenAskedToRender(<PhotoAlbum layout={"rows"} photos={photos} maxPhotoCount={4} />);
+    it("supports maximum number of elements in a row", () => {
+        whenAskedToRender(<PhotoAlbum layout={"rows"} photos={photos} rowConstraints={{ maxPhotos: 4 }} />);
     });
 
     it("renders columns layout correctly when there isn't enough photos", () => {

--- a/test/PhotoAlbum.test.tsx
+++ b/test/PhotoAlbum.test.tsx
@@ -55,6 +55,14 @@ describe("PhotoAlbum", () => {
         whenAskedToRender(<PhotoAlbum layout={"rows"} photos={photos} padding={10} />);
     });
 
+    it("supports minimum number of elements in a row ", () => {
+        whenAskedToRender(<PhotoAlbum layout={"rows"} photos={photos} minRowCount={3} />);
+    });
+
+    it("supports maximum number of elements in a row ", () => {
+        whenAskedToRender(<PhotoAlbum layout={"rows"} photos={photos} maxRowCount={4} />);
+    });
+
     it("renders columns layout correctly when there isn't enough photos", () => {
         whenAskedToRender(<PhotoAlbum layout={"columns"} photos={photos.slice(0, 3)} columns={5} />);
     });

--- a/test/__snapshots__/PhotoAlbum.test.tsx.snap
+++ b/test/__snapshots__/PhotoAlbum.test.tsx.snap
@@ -15747,6 +15747,818 @@ exports[`PhotoAlbum supports deterministic tiebreaker 1`] = `
 </div>
 `;
 
+exports[`PhotoAlbum supports minimum number of elements in a row  1`] = `
+<div
+  className="react-photo-album react-photo-album--rows"
+  style={
+    Object {
+      "display": "flex",
+      "flexDirection": "column",
+      "flexWrap": "nowrap",
+      "justifyContent": "space-between",
+    }
+  }
+>
+  <div
+    className="react-photo-album--row"
+    style={
+      Object {
+        "alignItems": "flex-start",
+        "display": "flex",
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "space-between",
+        "marginBottom": "15px",
+      }
+    }
+  >
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/Osq7UAVxIOI/1080x780"
+      style={
+        Object {
+          "aspectRatio": "1080 / 780",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.56481)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/Dhmn6ete6g8/1080x1620"
+      style={
+        Object {
+          "aspectRatio": "1080 / 1620",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 5.32692)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/RkBTPqPEGDo/1080x720"
+      style={
+        Object {
+          "aspectRatio": "1080 / 720",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.36752)",
+        }
+      }
+    />
+  </div>
+  <div
+    className="react-photo-album--row"
+    style={
+      Object {
+        "alignItems": "flex-start",
+        "display": "flex",
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "space-between",
+        "marginBottom": "15px",
+      }
+    }
+  >
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/Yizrl9N_eDA/1080x721"
+      style={
+        Object {
+          "aspectRatio": "1080 / 721",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.63287)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/KG3TyFi0iTU/1080x1620"
+      style={
+        Object {
+          "aspectRatio": "1080 / 1620",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 5.91574)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/Jztmx9yqjBw/1080x607"
+      style={
+        Object {
+          "aspectRatio": "1080 / 607",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.21658)",
+        }
+      }
+    />
+  </div>
+  <div
+    className="react-photo-album--row"
+    style={
+      Object {
+        "alignItems": "flex-start",
+        "display": "flex",
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "space-between",
+        "marginBottom": "15px",
+      }
+    }
+  >
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/-heLWtuAN3c/1080x608"
+      style={
+        Object {
+          "aspectRatio": "1080 / 608",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.23696)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/xOigCUcFdA8/1080x720"
+      style={
+        Object {
+          "aspectRatio": "1080 / 720",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.64903)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/1azAjl8FTnU/1080x1549"
+      style={
+        Object {
+          "aspectRatio": "1080 / 1549",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 5.69909)",
+        }
+      }
+    />
+  </div>
+  <div
+    className="react-photo-album--row"
+    style={
+      Object {
+        "alignItems": "flex-start",
+        "display": "flex",
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "space-between",
+        "marginBottom": "15px",
+      }
+    }
+  >
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/ALrCdq-ui_Q/1080x720"
+      style={
+        Object {
+          "aspectRatio": "1080 / 720",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.48191)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/twukN12EN7c/1080x694"
+      style={
+        Object {
+          "aspectRatio": "1080 / 694",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.39228)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/9UjEyzA6pP4/1080x1620"
+      style={
+        Object {
+          "aspectRatio": "1080 / 1620",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 5.58429)",
+        }
+      }
+    />
+  </div>
+  <div
+    className="react-photo-album--row"
+    style={
+      Object {
+        "alignItems": "flex-start",
+        "display": "flex",
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "space-between",
+        "marginBottom": "15px",
+      }
+    }
+  >
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/sEXGgun3ZiE/1080x720"
+      style={
+        Object {
+          "aspectRatio": "1080 / 720",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 1.94444)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/S-cdwrx-YuQ/1080x1440"
+      style={
+        Object {
+          "aspectRatio": "1080 / 1440",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 3.88889)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/q-motCAvPBM/1080x1620"
+      style={
+        Object {
+          "aspectRatio": "1080 / 1620",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 4.375)",
+        }
+      }
+    />
+  </div>
+  <div
+    className="react-photo-album--row"
+    style={
+      Object {
+        "alignItems": "flex-start",
+        "display": "flex",
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "space-between",
+        "marginBottom": "15px",
+      }
+    }
+  >
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/Xn4L310ztMU/1080x810"
+      style={
+        Object {
+          "aspectRatio": "1080 / 810",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 6.5625)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/ls94iFAQerE/1080x1620"
+      style={
+        Object {
+          "aspectRatio": "1080 / 1620",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 13.125)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/X48pUOPKf7A/1080x160"
+      style={
+        Object {
+          "aspectRatio": "1080 / 160",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 1.2963)",
+        }
+      }
+    />
+  </div>
+  <div
+    className="react-photo-album--row"
+    style={
+      Object {
+        "alignItems": "flex-start",
+        "display": "flex",
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "space-between",
+      }
+    }
+  >
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/GbLS6YVXj0U/1080x810"
+      style={
+        Object {
+          "aspectRatio": "1080 / 810",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.6875)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/9CRd1J1rEOM/1080x720"
+      style={
+        Object {
+          "aspectRatio": "1080 / 720",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.38889)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/xKhtkhc9HbQ/1080x1440"
+      style={
+        Object {
+          "aspectRatio": "1080 / 1440",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 4.77778)",
+        }
+      }
+    />
+  </div>
+</div>
+`;
+
+exports[`PhotoAlbum supports minimum number of elements in a row  2`] = `
+<div
+  className="react-photo-album react-photo-album--rows"
+  style={
+    Object {
+      "display": "flex",
+      "flexDirection": "column",
+      "flexWrap": "nowrap",
+      "justifyContent": "space-between",
+    }
+  }
+>
+  <div
+    className="react-photo-album--row"
+    style={
+      Object {
+        "alignItems": "flex-start",
+        "display": "flex",
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "space-between",
+        "marginBottom": "15px",
+      }
+    }
+  >
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/Osq7UAVxIOI/1080x780"
+      style={
+        Object {
+          "aspectRatio": "1080 / 780",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 45px) / 3.64665)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/Dhmn6ete6g8/1080x1620"
+      style={
+        Object {
+          "aspectRatio": "1080 / 1620",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 45px) / 7.5738)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/RkBTPqPEGDo/1080x720"
+      style={
+        Object {
+          "aspectRatio": "1080 / 720",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 45px) / 3.36613)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/Yizrl9N_eDA/1080x721"
+      style={
+        Object {
+          "aspectRatio": "1080 / 721",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 45px) / 3.37081)",
+        }
+      }
+    />
+  </div>
+  <div
+    className="react-photo-album--row"
+    style={
+      Object {
+        "alignItems": "flex-start",
+        "display": "flex",
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "space-between",
+        "marginBottom": "15px",
+      }
+    }
+  >
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/KG3TyFi0iTU/1080x1620"
+      style={
+        Object {
+          "aspectRatio": "1080 / 1620",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 6.33334)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/Jztmx9yqjBw/1080x607"
+      style={
+        Object {
+          "aspectRatio": "1080 / 607",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.37305)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/-heLWtuAN3c/1080x608"
+      style={
+        Object {
+          "aspectRatio": "1080 / 608",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.37696)",
+        }
+      }
+    />
+  </div>
+  <div
+    className="react-photo-album--row"
+    style={
+      Object {
+        "alignItems": "flex-start",
+        "display": "flex",
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "space-between",
+        "marginBottom": "15px",
+      }
+    }
+  >
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/xOigCUcFdA8/1080x720"
+      style={
+        Object {
+          "aspectRatio": "1080 / 720",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.46482)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/1azAjl8FTnU/1080x1549"
+      style={
+        Object {
+          "aspectRatio": "1080 / 1549",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 5.30278)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/ALrCdq-ui_Q/1080x720"
+      style={
+        Object {
+          "aspectRatio": "1080 / 720",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.46482)",
+        }
+      }
+    />
+  </div>
+  <div
+    className="react-photo-album--row"
+    style={
+      Object {
+        "alignItems": "flex-start",
+        "display": "flex",
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "space-between",
+        "marginBottom": "15px",
+      }
+    }
+  >
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/twukN12EN7c/1080x694"
+      style={
+        Object {
+          "aspectRatio": "1080 / 694",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.39228)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/9UjEyzA6pP4/1080x1620"
+      style={
+        Object {
+          "aspectRatio": "1080 / 1620",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 5.58429)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/sEXGgun3ZiE/1080x720"
+      style={
+        Object {
+          "aspectRatio": "1080 / 720",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.48191)",
+        }
+      }
+    />
+  </div>
+  <div
+    className="react-photo-album--row"
+    style={
+      Object {
+        "alignItems": "flex-start",
+        "display": "flex",
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "space-between",
+        "marginBottom": "15px",
+      }
+    }
+  >
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/S-cdwrx-YuQ/1080x1440"
+      style={
+        Object {
+          "aspectRatio": "1080 / 1440",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 45px) / 4.55556)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/q-motCAvPBM/1080x1620"
+      style={
+        Object {
+          "aspectRatio": "1080 / 1620",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 45px) / 5.125)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/Xn4L310ztMU/1080x810"
+      style={
+        Object {
+          "aspectRatio": "1080 / 810",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 45px) / 2.5625)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/ls94iFAQerE/1080x1620"
+      style={
+        Object {
+          "aspectRatio": "1080 / 1620",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 45px) / 5.125)",
+        }
+      }
+    />
+  </div>
+  <div
+    className="react-photo-album--row"
+    style={
+      Object {
+        "alignItems": "flex-start",
+        "display": "flex",
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "space-between",
+        "marginBottom": "15px",
+      }
+    }
+  >
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/X48pUOPKf7A/1080x160"
+      style={
+        Object {
+          "aspectRatio": "1080 / 160",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 0px) / 1)",
+        }
+      }
+    />
+  </div>
+  <div
+    className="react-photo-album--row"
+    style={
+      Object {
+        "alignItems": "flex-start",
+        "display": "flex",
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "space-between",
+      }
+    }
+  >
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/GbLS6YVXj0U/1080x810"
+      style={
+        Object {
+          "aspectRatio": "1080 / 810",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.6875)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/9CRd1J1rEOM/1080x720"
+      style={
+        Object {
+          "aspectRatio": "1080 / 720",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.38889)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/xKhtkhc9HbQ/1080x1440"
+      style={
+        Object {
+          "aspectRatio": "1080 / 1440",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 4.77778)",
+        }
+      }
+    />
+  </div>
+</div>
+`;
+
 exports[`PhotoAlbum supports padding 1`] = `
 <div
   className="react-photo-album react-photo-album--rows"

--- a/test/__snapshots__/PhotoAlbum.test.tsx.snap
+++ b/test/__snapshots__/PhotoAlbum.test.tsx.snap
@@ -15747,6 +15747,412 @@ exports[`PhotoAlbum supports deterministic tiebreaker 1`] = `
 </div>
 `;
 
+exports[`PhotoAlbum supports maximum number of elements in a row  1`] = `
+<div
+  className="react-photo-album react-photo-album--rows"
+  style={
+    Object {
+      "display": "flex",
+      "flexDirection": "column",
+      "flexWrap": "nowrap",
+      "justifyContent": "space-between",
+    }
+  }
+>
+  <div
+    className="react-photo-album--row"
+    style={
+      Object {
+        "alignItems": "flex-start",
+        "display": "flex",
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "space-between",
+        "marginBottom": "15px",
+      }
+    }
+  >
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/Osq7UAVxIOI/1080x780"
+      style={
+        Object {
+          "aspectRatio": "1080 / 780",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 45px) / 3.64665)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/Dhmn6ete6g8/1080x1620"
+      style={
+        Object {
+          "aspectRatio": "1080 / 1620",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 45px) / 7.5738)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/RkBTPqPEGDo/1080x720"
+      style={
+        Object {
+          "aspectRatio": "1080 / 720",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 45px) / 3.36613)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/Yizrl9N_eDA/1080x721"
+      style={
+        Object {
+          "aspectRatio": "1080 / 721",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 45px) / 3.37081)",
+        }
+      }
+    />
+  </div>
+  <div
+    className="react-photo-album--row"
+    style={
+      Object {
+        "alignItems": "flex-start",
+        "display": "flex",
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "space-between",
+        "marginBottom": "15px",
+      }
+    }
+  >
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/KG3TyFi0iTU/1080x1620"
+      style={
+        Object {
+          "aspectRatio": "1080 / 1620",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 6.33334)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/Jztmx9yqjBw/1080x607"
+      style={
+        Object {
+          "aspectRatio": "1080 / 607",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.37305)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/-heLWtuAN3c/1080x608"
+      style={
+        Object {
+          "aspectRatio": "1080 / 608",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.37696)",
+        }
+      }
+    />
+  </div>
+  <div
+    className="react-photo-album--row"
+    style={
+      Object {
+        "alignItems": "flex-start",
+        "display": "flex",
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "space-between",
+        "marginBottom": "15px",
+      }
+    }
+  >
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/xOigCUcFdA8/1080x720"
+      style={
+        Object {
+          "aspectRatio": "1080 / 720",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.46482)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/1azAjl8FTnU/1080x1549"
+      style={
+        Object {
+          "aspectRatio": "1080 / 1549",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 5.30278)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/ALrCdq-ui_Q/1080x720"
+      style={
+        Object {
+          "aspectRatio": "1080 / 720",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.46482)",
+        }
+      }
+    />
+  </div>
+  <div
+    className="react-photo-album--row"
+    style={
+      Object {
+        "alignItems": "flex-start",
+        "display": "flex",
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "space-between",
+        "marginBottom": "15px",
+      }
+    }
+  >
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/twukN12EN7c/1080x694"
+      style={
+        Object {
+          "aspectRatio": "1080 / 694",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.39228)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/9UjEyzA6pP4/1080x1620"
+      style={
+        Object {
+          "aspectRatio": "1080 / 1620",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 5.58429)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/sEXGgun3ZiE/1080x720"
+      style={
+        Object {
+          "aspectRatio": "1080 / 720",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.48191)",
+        }
+      }
+    />
+  </div>
+  <div
+    className="react-photo-album--row"
+    style={
+      Object {
+        "alignItems": "flex-start",
+        "display": "flex",
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "space-between",
+        "marginBottom": "15px",
+      }
+    }
+  >
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/S-cdwrx-YuQ/1080x1440"
+      style={
+        Object {
+          "aspectRatio": "1080 / 1440",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 45px) / 4.55556)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/q-motCAvPBM/1080x1620"
+      style={
+        Object {
+          "aspectRatio": "1080 / 1620",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 45px) / 5.125)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/Xn4L310ztMU/1080x810"
+      style={
+        Object {
+          "aspectRatio": "1080 / 810",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 45px) / 2.5625)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/ls94iFAQerE/1080x1620"
+      style={
+        Object {
+          "aspectRatio": "1080 / 1620",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 45px) / 5.125)",
+        }
+      }
+    />
+  </div>
+  <div
+    className="react-photo-album--row"
+    style={
+      Object {
+        "alignItems": "flex-start",
+        "display": "flex",
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "space-between",
+        "marginBottom": "15px",
+      }
+    }
+  >
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/X48pUOPKf7A/1080x160"
+      style={
+        Object {
+          "aspectRatio": "1080 / 160",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 0px) / 1)",
+        }
+      }
+    />
+  </div>
+  <div
+    className="react-photo-album--row"
+    style={
+      Object {
+        "alignItems": "flex-start",
+        "display": "flex",
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "space-between",
+      }
+    }
+  >
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/GbLS6YVXj0U/1080x810"
+      style={
+        Object {
+          "aspectRatio": "1080 / 810",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.6875)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/9CRd1J1rEOM/1080x720"
+      style={
+        Object {
+          "aspectRatio": "1080 / 720",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 2.38889)",
+        }
+      }
+    />
+    <img
+      alt=""
+      className="react-photo-album--photo"
+      src="https://source.unsplash.com/xKhtkhc9HbQ/1080x1440"
+      style={
+        Object {
+          "aspectRatio": "1080 / 1440",
+          "boxSizing": "content-box",
+          "display": "block",
+          "height": "auto",
+          "width": "calc((100% - 30px) / 4.77778)",
+        }
+      }
+    />
+  </div>
+</div>
+`;
+
 exports[`PhotoAlbum supports minimum number of elements in a row  1`] = `
 <div
   className="react-photo-album react-photo-album--rows"
@@ -16091,412 +16497,6 @@ exports[`PhotoAlbum supports minimum number of elements in a row  1`] = `
           "display": "block",
           "height": "auto",
           "width": "calc((100% - 30px) / 1.2963)",
-        }
-      }
-    />
-  </div>
-  <div
-    className="react-photo-album--row"
-    style={
-      Object {
-        "alignItems": "flex-start",
-        "display": "flex",
-        "flexDirection": "row",
-        "flexWrap": "nowrap",
-        "justifyContent": "space-between",
-      }
-    }
-  >
-    <img
-      alt=""
-      className="react-photo-album--photo"
-      src="https://source.unsplash.com/GbLS6YVXj0U/1080x810"
-      style={
-        Object {
-          "aspectRatio": "1080 / 810",
-          "boxSizing": "content-box",
-          "display": "block",
-          "height": "auto",
-          "width": "calc((100% - 30px) / 2.6875)",
-        }
-      }
-    />
-    <img
-      alt=""
-      className="react-photo-album--photo"
-      src="https://source.unsplash.com/9CRd1J1rEOM/1080x720"
-      style={
-        Object {
-          "aspectRatio": "1080 / 720",
-          "boxSizing": "content-box",
-          "display": "block",
-          "height": "auto",
-          "width": "calc((100% - 30px) / 2.38889)",
-        }
-      }
-    />
-    <img
-      alt=""
-      className="react-photo-album--photo"
-      src="https://source.unsplash.com/xKhtkhc9HbQ/1080x1440"
-      style={
-        Object {
-          "aspectRatio": "1080 / 1440",
-          "boxSizing": "content-box",
-          "display": "block",
-          "height": "auto",
-          "width": "calc((100% - 30px) / 4.77778)",
-        }
-      }
-    />
-  </div>
-</div>
-`;
-
-exports[`PhotoAlbum supports minimum number of elements in a row  2`] = `
-<div
-  className="react-photo-album react-photo-album--rows"
-  style={
-    Object {
-      "display": "flex",
-      "flexDirection": "column",
-      "flexWrap": "nowrap",
-      "justifyContent": "space-between",
-    }
-  }
->
-  <div
-    className="react-photo-album--row"
-    style={
-      Object {
-        "alignItems": "flex-start",
-        "display": "flex",
-        "flexDirection": "row",
-        "flexWrap": "nowrap",
-        "justifyContent": "space-between",
-        "marginBottom": "15px",
-      }
-    }
-  >
-    <img
-      alt=""
-      className="react-photo-album--photo"
-      src="https://source.unsplash.com/Osq7UAVxIOI/1080x780"
-      style={
-        Object {
-          "aspectRatio": "1080 / 780",
-          "boxSizing": "content-box",
-          "display": "block",
-          "height": "auto",
-          "width": "calc((100% - 45px) / 3.64665)",
-        }
-      }
-    />
-    <img
-      alt=""
-      className="react-photo-album--photo"
-      src="https://source.unsplash.com/Dhmn6ete6g8/1080x1620"
-      style={
-        Object {
-          "aspectRatio": "1080 / 1620",
-          "boxSizing": "content-box",
-          "display": "block",
-          "height": "auto",
-          "width": "calc((100% - 45px) / 7.5738)",
-        }
-      }
-    />
-    <img
-      alt=""
-      className="react-photo-album--photo"
-      src="https://source.unsplash.com/RkBTPqPEGDo/1080x720"
-      style={
-        Object {
-          "aspectRatio": "1080 / 720",
-          "boxSizing": "content-box",
-          "display": "block",
-          "height": "auto",
-          "width": "calc((100% - 45px) / 3.36613)",
-        }
-      }
-    />
-    <img
-      alt=""
-      className="react-photo-album--photo"
-      src="https://source.unsplash.com/Yizrl9N_eDA/1080x721"
-      style={
-        Object {
-          "aspectRatio": "1080 / 721",
-          "boxSizing": "content-box",
-          "display": "block",
-          "height": "auto",
-          "width": "calc((100% - 45px) / 3.37081)",
-        }
-      }
-    />
-  </div>
-  <div
-    className="react-photo-album--row"
-    style={
-      Object {
-        "alignItems": "flex-start",
-        "display": "flex",
-        "flexDirection": "row",
-        "flexWrap": "nowrap",
-        "justifyContent": "space-between",
-        "marginBottom": "15px",
-      }
-    }
-  >
-    <img
-      alt=""
-      className="react-photo-album--photo"
-      src="https://source.unsplash.com/KG3TyFi0iTU/1080x1620"
-      style={
-        Object {
-          "aspectRatio": "1080 / 1620",
-          "boxSizing": "content-box",
-          "display": "block",
-          "height": "auto",
-          "width": "calc((100% - 30px) / 6.33334)",
-        }
-      }
-    />
-    <img
-      alt=""
-      className="react-photo-album--photo"
-      src="https://source.unsplash.com/Jztmx9yqjBw/1080x607"
-      style={
-        Object {
-          "aspectRatio": "1080 / 607",
-          "boxSizing": "content-box",
-          "display": "block",
-          "height": "auto",
-          "width": "calc((100% - 30px) / 2.37305)",
-        }
-      }
-    />
-    <img
-      alt=""
-      className="react-photo-album--photo"
-      src="https://source.unsplash.com/-heLWtuAN3c/1080x608"
-      style={
-        Object {
-          "aspectRatio": "1080 / 608",
-          "boxSizing": "content-box",
-          "display": "block",
-          "height": "auto",
-          "width": "calc((100% - 30px) / 2.37696)",
-        }
-      }
-    />
-  </div>
-  <div
-    className="react-photo-album--row"
-    style={
-      Object {
-        "alignItems": "flex-start",
-        "display": "flex",
-        "flexDirection": "row",
-        "flexWrap": "nowrap",
-        "justifyContent": "space-between",
-        "marginBottom": "15px",
-      }
-    }
-  >
-    <img
-      alt=""
-      className="react-photo-album--photo"
-      src="https://source.unsplash.com/xOigCUcFdA8/1080x720"
-      style={
-        Object {
-          "aspectRatio": "1080 / 720",
-          "boxSizing": "content-box",
-          "display": "block",
-          "height": "auto",
-          "width": "calc((100% - 30px) / 2.46482)",
-        }
-      }
-    />
-    <img
-      alt=""
-      className="react-photo-album--photo"
-      src="https://source.unsplash.com/1azAjl8FTnU/1080x1549"
-      style={
-        Object {
-          "aspectRatio": "1080 / 1549",
-          "boxSizing": "content-box",
-          "display": "block",
-          "height": "auto",
-          "width": "calc((100% - 30px) / 5.30278)",
-        }
-      }
-    />
-    <img
-      alt=""
-      className="react-photo-album--photo"
-      src="https://source.unsplash.com/ALrCdq-ui_Q/1080x720"
-      style={
-        Object {
-          "aspectRatio": "1080 / 720",
-          "boxSizing": "content-box",
-          "display": "block",
-          "height": "auto",
-          "width": "calc((100% - 30px) / 2.46482)",
-        }
-      }
-    />
-  </div>
-  <div
-    className="react-photo-album--row"
-    style={
-      Object {
-        "alignItems": "flex-start",
-        "display": "flex",
-        "flexDirection": "row",
-        "flexWrap": "nowrap",
-        "justifyContent": "space-between",
-        "marginBottom": "15px",
-      }
-    }
-  >
-    <img
-      alt=""
-      className="react-photo-album--photo"
-      src="https://source.unsplash.com/twukN12EN7c/1080x694"
-      style={
-        Object {
-          "aspectRatio": "1080 / 694",
-          "boxSizing": "content-box",
-          "display": "block",
-          "height": "auto",
-          "width": "calc((100% - 30px) / 2.39228)",
-        }
-      }
-    />
-    <img
-      alt=""
-      className="react-photo-album--photo"
-      src="https://source.unsplash.com/9UjEyzA6pP4/1080x1620"
-      style={
-        Object {
-          "aspectRatio": "1080 / 1620",
-          "boxSizing": "content-box",
-          "display": "block",
-          "height": "auto",
-          "width": "calc((100% - 30px) / 5.58429)",
-        }
-      }
-    />
-    <img
-      alt=""
-      className="react-photo-album--photo"
-      src="https://source.unsplash.com/sEXGgun3ZiE/1080x720"
-      style={
-        Object {
-          "aspectRatio": "1080 / 720",
-          "boxSizing": "content-box",
-          "display": "block",
-          "height": "auto",
-          "width": "calc((100% - 30px) / 2.48191)",
-        }
-      }
-    />
-  </div>
-  <div
-    className="react-photo-album--row"
-    style={
-      Object {
-        "alignItems": "flex-start",
-        "display": "flex",
-        "flexDirection": "row",
-        "flexWrap": "nowrap",
-        "justifyContent": "space-between",
-        "marginBottom": "15px",
-      }
-    }
-  >
-    <img
-      alt=""
-      className="react-photo-album--photo"
-      src="https://source.unsplash.com/S-cdwrx-YuQ/1080x1440"
-      style={
-        Object {
-          "aspectRatio": "1080 / 1440",
-          "boxSizing": "content-box",
-          "display": "block",
-          "height": "auto",
-          "width": "calc((100% - 45px) / 4.55556)",
-        }
-      }
-    />
-    <img
-      alt=""
-      className="react-photo-album--photo"
-      src="https://source.unsplash.com/q-motCAvPBM/1080x1620"
-      style={
-        Object {
-          "aspectRatio": "1080 / 1620",
-          "boxSizing": "content-box",
-          "display": "block",
-          "height": "auto",
-          "width": "calc((100% - 45px) / 5.125)",
-        }
-      }
-    />
-    <img
-      alt=""
-      className="react-photo-album--photo"
-      src="https://source.unsplash.com/Xn4L310ztMU/1080x810"
-      style={
-        Object {
-          "aspectRatio": "1080 / 810",
-          "boxSizing": "content-box",
-          "display": "block",
-          "height": "auto",
-          "width": "calc((100% - 45px) / 2.5625)",
-        }
-      }
-    />
-    <img
-      alt=""
-      className="react-photo-album--photo"
-      src="https://source.unsplash.com/ls94iFAQerE/1080x1620"
-      style={
-        Object {
-          "aspectRatio": "1080 / 1620",
-          "boxSizing": "content-box",
-          "display": "block",
-          "height": "auto",
-          "width": "calc((100% - 45px) / 5.125)",
-        }
-      }
-    />
-  </div>
-  <div
-    className="react-photo-album--row"
-    style={
-      Object {
-        "alignItems": "flex-start",
-        "display": "flex",
-        "flexDirection": "row",
-        "flexWrap": "nowrap",
-        "justifyContent": "space-between",
-        "marginBottom": "15px",
-      }
-    }
-  >
-    <img
-      alt=""
-      className="react-photo-album--photo"
-      src="https://source.unsplash.com/X48pUOPKf7A/1080x160"
-      style={
-        Object {
-          "aspectRatio": "1080 / 160",
-          "boxSizing": "content-box",
-          "display": "block",
-          "height": "auto",
-          "width": "calc((100% - 0px) / 1)",
         }
       }
     />

--- a/test/__snapshots__/PhotoAlbum.test.tsx.snap
+++ b/test/__snapshots__/PhotoAlbum.test.tsx.snap
@@ -15747,7 +15747,7 @@ exports[`PhotoAlbum supports deterministic tiebreaker 1`] = `
 </div>
 `;
 
-exports[`PhotoAlbum supports maximum number of elements in a row  1`] = `
+exports[`PhotoAlbum supports maximum number of elements in a row 1`] = `
 <div
   className="react-photo-album react-photo-album--rows"
   style={
@@ -16153,7 +16153,7 @@ exports[`PhotoAlbum supports maximum number of elements in a row  1`] = `
 </div>
 `;
 
-exports[`PhotoAlbum supports minimum number of elements in a row  1`] = `
+exports[`PhotoAlbum supports minimum number of elements in a row 1`] = `
 <div
   className="react-photo-album react-photo-album--rows"
   style={


### PR DESCRIPTION
<!-- Thank you so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed the 'Sending a Pull Request' section of the [contributing guide](https://github.com/igordanchenko/react-photo-album/blob/main/CONTRIBUTING.md#sending-a-pull-request)


### Summary 
This PR introduces 2 new props which provide more control to the end-user on row layout.

`minPhotoCount` - absolute minimum number of elements (Photos) allowed in a row.
`maxPhotoCount` - targeted maximum number of elements (Photos) allowed in a row. 

### Techincal choices
-  `maxPhotoCount` will be overridden by `limitNodeSearch` if its value is greater than the guestimated value for performance's sake.
