### PR TITLE
feat: adding CSS filter property to the photos

### DIFF
--- a/src/PhotoAlbum.tsx
+++ b/src/PhotoAlbum.tsx
@@ -49,11 +49,11 @@ function renderLayout<T extends Photo>(
     containerWidth: number,
     componentsProps: ComponentsProps | undefined
 ) {
-    const { photos, layout, renderPhoto, renderRowContainer, renderColumnContainer } = props;
+    const { photos, layout, filter: filterOptions, renderPhoto, renderRowContainer, renderColumnContainer } = props;
 
     const layoutOptions = resolveLayoutOptions({ containerWidth, ...props });
 
-    const commonLayoutProps = { photos, renderPhoto, componentsProps };
+    const commonLayoutProps = { photos, filterOptions, renderPhoto, componentsProps };
 
     if (layout === "rows") {
         return (

--- a/src/components/layouts/ColumnsLayout.tsx
+++ b/src/components/layouts/ColumnsLayout.tsx
@@ -8,13 +8,14 @@ import { ColumnsLayoutOptions, ComponentsProps, Photo, RenderColumnContainer, Re
 export type ColumnsLayoutProps<T extends Photo = Photo> = {
     photos: T[];
     layoutOptions: ColumnsLayoutOptions<T>;
+    filterOptions?: string;
     renderPhoto?: RenderPhoto<T>;
     renderColumnContainer?: RenderColumnContainer<T>;
     componentsProps?: ComponentsProps;
 };
 
 export default function ColumnsLayout<T extends Photo = Photo>(props: ColumnsLayoutProps<T>) {
-    const { photos, layoutOptions, renderPhoto, renderColumnContainer, componentsProps } = props;
+    const { photos, layoutOptions, filterOptions, renderPhoto, renderColumnContainer, componentsProps } = props;
 
     const columnsLayout = computeColumnsLayout({ photos, layoutOptions });
 
@@ -42,6 +43,7 @@ export default function ColumnsLayout<T extends Photo = Photo>(props: ColumnsLay
                             photo={photo}
                             layout={layout}
                             layoutOptions={layoutOptions}
+                            filterOptions={filterOptions}
                             renderPhoto={renderPhoto}
                             imageProps={componentsProps?.imageProps}
                         />

--- a/src/components/layouts/MasonryLayout.tsx
+++ b/src/components/layouts/MasonryLayout.tsx
@@ -8,13 +8,14 @@ import { ColumnsLayoutOptions, ComponentsProps, Photo, RenderColumnContainer, Re
 export type MasonryLayoutProps<T extends Photo = Photo> = {
     photos: T[];
     layoutOptions: ColumnsLayoutOptions<T>;
+    filterOptions?: string;
     renderPhoto?: RenderPhoto<T>;
     renderColumnContainer?: RenderColumnContainer<T>;
     componentsProps?: ComponentsProps;
 };
 
 export default function MasonryLayout<T extends Photo = Photo>(props: MasonryLayoutProps<T>) {
-    const { photos, layoutOptions, renderPhoto, renderColumnContainer, componentsProps } = props;
+    const { photos, layoutOptions, filterOptions, renderPhoto, renderColumnContainer, componentsProps } = props;
 
     const masonryLayout = computeMasonryLayout({ photos, layoutOptions });
 
@@ -38,6 +39,7 @@ export default function MasonryLayout<T extends Photo = Photo>(props: MasonryLay
                             photo={photo}
                             layout={layout}
                             layoutOptions={layoutOptions}
+                            filterOptions={filterOptions}
                             renderPhoto={renderPhoto}
                             imageProps={componentsProps?.imageProps}
                         />

--- a/src/components/layouts/RowsLayout.tsx
+++ b/src/components/layouts/RowsLayout.tsx
@@ -8,13 +8,14 @@ import { ComponentsProps, Photo, RenderPhoto, RenderRowContainer, RowsLayoutOpti
 export type RowsLayoutProps<T extends Photo = Photo> = {
     photos: T[];
     layoutOptions: RowsLayoutOptions<T>;
+    filterOptions?: string;
     renderPhoto?: RenderPhoto<T>;
     renderRowContainer?: RenderRowContainer<T>;
     componentsProps?: ComponentsProps;
 };
 
 export default function RowsLayout<T extends Photo = Photo>(props: RowsLayoutProps<T>) {
-    const { photos, layoutOptions, renderPhoto, renderRowContainer, componentsProps } = props;
+    const { photos, layoutOptions, filterOptions, renderPhoto, renderRowContainer, componentsProps } = props;
 
     const rowsLayout = computeRowsLayout({ photos, layoutOptions });
 
@@ -38,6 +39,7 @@ export default function RowsLayout<T extends Photo = Photo>(props: RowsLayoutPro
                             photo={photo}
                             layout={layout}
                             layoutOptions={layoutOptions}
+                            filterOptions={filterOptions}
                             renderPhoto={renderPhoto}
                             imageProps={componentsProps?.imageProps}
                         />

--- a/src/components/renderers/PhotoRenderer.tsx
+++ b/src/components/renderers/PhotoRenderer.tsx
@@ -70,6 +70,7 @@ export default function PhotoRenderer<T extends Photo = Photo>(props: PhotoRende
         photo,
         layout,
         layoutOptions,
+        filterOptions,
         imageProps: { style, className, ...restImageProps } = {},
         renderPhoto,
     } = props;
@@ -80,6 +81,7 @@ export default function PhotoRenderer<T extends Photo = Photo>(props: PhotoRende
         boxSizing: "content-box",
         width: cssPhotoWidth(layout, layoutOptions),
         height: "auto",
+        filter: filterOptions,
         aspectRatio: `${photo.width} / ${photo.height}`,
         ...(layoutOptions.padding ? { padding: `${layoutOptions.padding}px` } : null),
         ...((layoutOptions.layout === "columns" || layoutOptions.layout === "masonry") &&

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,8 @@ export type PhotoAlbumProps<T extends Photo = Photo> = {
     defaultContainerWidth?: number;
     /** Additional HTML attributes to be passed to the rendered elements. */
     componentsProps?: ComponentsPropsParameter;
+    /** Photos css filter. */
+    filter?: string;
     /** Custom photo rendering function. */
     renderPhoto?: RenderPhoto<T>;
     /** Custom container rendering function. */
@@ -67,6 +69,8 @@ export type RenderPhotoProps<T extends Photo = Photo> = {
     layout: PhotoLayout;
     /** photo album layout options */
     layoutOptions: LayoutOptions<T>;
+    /** photo css filter options. */
+    filterOptions?: string;
     /** pre-populated 'img' element attributes */
     imageProps: NonOptional<ImageElementAttributes, "src" | "alt" | "style">;
     /** A callback to render the default photo implementation. If `wrapped` is `true`, the image is styled with `width`


### PR DESCRIPTION
<!-- Thank you so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed the 'Sending a Pull Request' section of the [contributing guide](https://github.com/igordanchenko/react-photo-album/blob/main/CONTRIBUTING.md#sending-a-pull-request)

The " filter " property defines visual effects (like blur and grayscale) to an img element:

`<PhotoAlbum filter="grayscale(1) drop-shadow(4px 4px 16px black)" layout="rows" photos={photos} />`

![Untitled](https://github.com/igordanchenko/react-photo-album/assets/53819019/e2010393-5958-4955-a59d-a8d19376ec39)

All these values can be used:
filter: none | blur() | brightness() | contrast() | drop-shadow() | grayscale() | hue-rotate() | invert() | opacity() | saturate() | sepia() | URL();

https://www.w3schools.com/cssref/css3_pr_filter.php
